### PR TITLE
fix setCustomResponse method

### DIFF
--- a/src/router/RouterResponse.ts
+++ b/src/router/RouterResponse.ts
@@ -235,6 +235,7 @@ export default class RouterResponse<AdditionalDataType extends unknown> {
      * @returns {this}
      */
     public setCustomResponse (response: Response): this {
+        this.responseOptions.type = "custom";
         this.responseOptions.customResponse = response;
         
         return this;


### PR DESCRIPTION
responseOptions.type should be set to custom when setting a custom Response object.